### PR TITLE
Correct run numbers for TCDS

### DIFF
--- a/gembase/src/common/GEMApplication.cc
+++ b/gembase/src/common/GEMApplication.cc
@@ -202,7 +202,7 @@ void gem::base::GEMApplication::actionPerformed(xdata::Event& event)
   // item is changed, update it
   if (event.type() == "ItemChangedEvent" ||
       event.type() == "urn:xdata-event:ItemChangedEvent") {
-    DEBUG("GEMApplication::actionPerformed() ItemChangedEvent"
+    INFO("GEMApplication::actionPerformed() ItemChangedEvent"
           << "m_runNumber:" << m_runNumber
           << " getInteger64(\"RunNumber\"):" << p_appInfoSpaceToolBox->getInteger64("RunNumber"));
 

--- a/gembase/src/common/GEMApplication.cc
+++ b/gembase/src/common/GEMApplication.cc
@@ -202,7 +202,7 @@ void gem::base::GEMApplication::actionPerformed(xdata::Event& event)
   // item is changed, update it
   if (event.type() == "ItemChangedEvent" ||
       event.type() == "urn:xdata-event:ItemChangedEvent") {
-    INFO("GEMApplication::actionPerformed() ItemChangedEvent"
+    DEBUG("GEMApplication::actionPerformed() ItemChangedEvent"
           << "m_runNumber:" << m_runNumber
           << " getInteger64(\"RunNumber\"):" << p_appInfoSpaceToolBox->getInteger64("RunNumber"));
 

--- a/gemsupervisor/src/common/GEMSupervisor.cc
+++ b/gemsupervisor/src/common/GEMSupervisor.cc
@@ -599,10 +599,9 @@ void gem::supervisor::GEMSupervisor::startAction()
         if (((*j)->getClassName()).rfind("tcds::") != std::string::npos) {
           std::unordered_map<std::string, xdata::Serializable*> tcdsParams;
           xdata::UnsignedInteger tcdsRunNumber(m_runNumber);
-          // tcdsRunNumber.value_ = m_runNumber.value_;
-          INFO("GEMSupervisor::startAction sending TCDS application " << (*j)->getClassName()
-               << " run number: " << m_runNumber.value_ << "(" << m_runNumber.toString() << ")"
-               << " as: " << tcdsRunNumber.value_ << "(" << tcdsRunNumber.toString() << ")");
+          DEBUG("GEMSupervisor::startAction sending TCDS application " << (*j)->getClassName()
+                << " run number: " << m_runNumber.value_ << "(" << m_runNumber.toString() << ")"
+                << " as: " << tcdsRunNumber.value_ << "(" << tcdsRunNumber.toString() << ")");
           tcdsParams.insert(std::make_pair("runNumber", &(tcdsRunNumber)));
           gem::utils::soap::GEMSOAPToolBox::sendCommandWithParameterBag("Enable", tcdsParams, p_appContext, p_appDescriptor, *j);
         } else {

--- a/gemsupervisor/src/common/GEMSupervisor.cc
+++ b/gemsupervisor/src/common/GEMSupervisor.cc
@@ -598,8 +598,8 @@ void gem::supervisor::GEMSupervisor::startAction()
         INFO("GEMSupervisor::startAction Starting " << (*j)->getClassName());
         if (((*j)->getClassName()).rfind("tcds::") != std::string::npos) {
           std::unordered_map<std::string, xdata::Serializable*> tcdsParams;
-          xdata::UnsignedInteger tcdsRunNumber;
-          tcdsRunNumber.value_ = m_runNumber.value_;
+          xdata::UnsignedInteger tcdsRunNumber(m_runNumber);
+          // tcdsRunNumber.value_ = m_runNumber.value_;
           INFO("GEMSupervisor::startAction sending TCDS application " << (*j)->getClassName()
                << " run number: " << m_runNumber.value_ << "(" << m_runNumber.toString() << ")"
                << " as: " << tcdsRunNumber.value_ << "(" << tcdsRunNumber.toString() << ")");

--- a/gemsupervisor/src/common/GEMSupervisor.cc
+++ b/gemsupervisor/src/common/GEMSupervisor.cc
@@ -578,7 +578,7 @@ void gem::supervisor::GEMSupervisor::startAction()
     XCEPT_RAISE(gem::supervisor::exception::Exception, msg.str());
   }
 
-  if(m_scanType.value_ == 2 || (m_scanType.value_ == 3)){
+  if (m_scanType.value_ == 2 || (m_scanType.value_ == 3)){
     m_scanParameter = m_scanInfo.bag.scanMin.value_;
     INFO("GEMSupervisor::startAction Scan");
     if (m_scanType.value_ == 2) {
@@ -1252,7 +1252,7 @@ void gem::supervisor::GEMSupervisor::sendRunType(std::string const& runType, xda
 void gem::supervisor::GEMSupervisor::sendRunNumber(int64_t const& runNumber, xdaq::ApplicationDescriptor* ad)
 //  throw (xoap::exception::Exception)
 {
-  INFO("GEMSupervisor::sendRunNumber to " << ad->getClassName());
+  INFO("GEMSupervisor::sendRunNumber " << m_runNumber.toString() << " to " << ad->getClassName());
   gem::utils::soap::GEMSOAPToolBox::sendApplicationParameter("RunNumber", "xsd:long",
                                                              m_runNumber.toString(),
                                                              p_appContext, p_appDescriptor, ad);

--- a/gemsupervisor/src/common/GEMSupervisor.cc
+++ b/gemsupervisor/src/common/GEMSupervisor.cc
@@ -600,6 +600,9 @@ void gem::supervisor::GEMSupervisor::startAction()
           std::unordered_map<std::string, xdata::Serializable*> tcdsParams;
           xdata::UnsignedInteger tcdsRunNumber;
           tcdsRunNumber.value_ = m_runNumber.value_;
+          INFO("GEMSupervisor::startAction sending TCDS application " << (*j)->getClassName()
+               << " run number: " << m_runNumber.value_ << "(" << m_runNumber.toString() << ")"
+               << " as: " << tcdsRunNumber.value_ << "(" << tcdsRunNumber.toString() << ")");
           tcdsParams.insert(std::make_pair("runNumber", &(tcdsRunNumber)));
           gem::utils::soap::GEMSOAPToolBox::sendCommandWithParameterBag("Enable", tcdsParams, p_appContext, p_appDescriptor, *j);
         } else {


### PR DESCRIPTION
* Run number being sent to TCDS was corrupted due to improper initialization
 * `toString` was resulting in `NaN`